### PR TITLE
:sparkles: Feat: user field add

### DIFF
--- a/velog/authentication/models.py
+++ b/velog/authentication/models.py
@@ -15,7 +15,13 @@ class User(AbstractUser):
     last_name = None
     email = models.EmailField(max_length=100, blank=False, null=False, unique=True)
     name = models.CharField(max_length=100, blank=True)
-
+    velog_name = models.CharField(max_length=100, blank=True)
+    mail = models.CharField(max_length=100, blank=True)
+    github = models.CharField(max_length=100, blank=True)
+    twitter = models.CharField(max_length=100, blank=True)
+    facebook = models.CharField(max_length=100, blank=True)
+    homepage = models.CharField(max_length=100, blank=True)
+    about = models.TextField(blank=True)
     profile_image = models.ImageField(upload_to="authentication/pictures", blank=True)
     introduction = models.CharField(max_length=100, blank=True)
     is_staff = models.BooleanField(default=False)

--- a/velog/authentication/serializers.py
+++ b/velog/authentication/serializers.py
@@ -12,13 +12,20 @@ from .models import User
 class UserSerializer(UserDetailsSerializer):
     class Meta:
         model = User
+        model = User
         fields = [
-            "id",
             "username",
             "email",
             "name",
             "profile_image",
             "introduction",
+            "mail",
+            "github",
+            "twitter",
+            "facebook",
+            "homepage",
+            "velog_name",
+            "about",
         ]
         read_only_fields = [
             "email",
@@ -52,11 +59,18 @@ class CustomRegisterSerializer(RegisterSerializer):
     def get_cleaned_data(self):
         return {
             "username": self.validated_data.get("username", ""),
+            "velog_name": self.validated_data.get("username", "") + ".log",
             "password1": self.validated_data.get("password1", ""),
             "email": self.validated_data.get("email", ""),
             "name": self.validated_data.get("name", ""),
             "profile_image": self.validated_data.get("profile_image", ""),
             "introduction": self.validated_data.get("introduction", ""),
+            "mail": self.validated_data.get("mail", ""),
+            "github": self.validated_data.get("github", ""),
+            "twitter": self.validated_data.get("twitter", ""),
+            "facebook": self.validated_data.get("facebook", ""),
+            "homepage": self.validated_data.get("homepage", ""),
+            "about": self.validated_data.get("about", ""),
         }
 
     def save(self, request):
@@ -72,9 +86,16 @@ class CustomRegisterSerializer(RegisterSerializer):
                 raise serializers.ValidationError(
                     detail=serializers.as_serializer_error(exc)
                 )
+        user.velog_name = self.validated_data.get("username", "") + ".log"
         user.name = self.validated_data.get("name", "")
         user.profile_image = self.validated_data.get("profile_image", "")
         user.introduction = self.validated_data.get("introduction", "")
+        user.mail = self.validated_data.get("mail", "")
+        user.github = self.validated_data.get("github", "")
+        user.twitter = self.validated_data.get("twitter", "")
+        user.facebook = self.validated_data.get("facebook", "")
+        user.homepage = self.validated_data.get("homepage", "")
+        user.about = self.validated_data.get("about", "")
         user.save()
         self.custom_signup(request, user)
         setup_user_email(request, user, [])

--- a/velog/authentication/urls.py
+++ b/velog/authentication/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("login/", LoginView.as_view(), name='rest_login'),
     path("logout/", LogoutView.as_view(), name='rest_logout'),
     path("user/", UserDetailsView.as_view(), name="user_detail"),
+    path("user/@<str:username>", views.UsernameView.as_view(), name="username_view"),
     path("signup/", RegisterView.as_view(), name="account_signup"),
     path("login/", LoginView.as_view(), name="account_login"),
     path("logout/", LogoutView.as_view(), name="account_logout"),

--- a/velog/authentication/views.py
+++ b/velog/authentication/views.py
@@ -14,11 +14,12 @@ from dj_rest_auth.registration.views import SocialConnectView, SocialLoginView
 from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import redirect
-from rest_framework import status
+from rest_framework import status, generics, permissions
+from rest_framework.response import Response
 from rest_framework.views import APIView 
 from rest_framework.permissions import AllowAny
-
 from .models import User
+from .serializers import UserSerializer
 
 BASE_URL = "https://api.7elog.store/api/v1/"
 
@@ -38,6 +39,17 @@ GITHUB_CALLBACK_URI = BASE_URL + "accounts/github/login/callback/"
 FACEBOOK_CALLBACK_URI = BASE_URL + "accounts/facebook/login/callback/"
 
 state = getattr(settings, "STATE")
+
+
+class UsernameView(generics.ListAPIView):
+    permission_classes = [permissions.AllowAny]
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+
+    def get(self, request, *args, **kwargs):
+        queryset = self.get_queryset().get(username=kwargs['username'])
+        serializer = self.serializer_class(queryset)
+        return Response(serializer.data)
 
 
 def google_login(request):


### PR DESCRIPTION
기능상으로 크게 추가한 것은 없습니다. 우선 자동적으로 velog_name같은 경우 회원가입시 username에 .log를 붙인 값으로 입력되도록 해서 나중에는 둘이 서로간에 상관없이 수정할 수 있도록 해주었습니다. 그리고 github, twitter, facebook, homepage, mail, about과 같은 field를 추가하였는데 about의 경우에는 따로 수정하지만 어차피 patch method로 api/v1/accounts/user/로 일부만 수정이 가능하기에 굳이 구분지을 필요없어 합쳐서 넣었습니다. 이후 할 계획은 지금 tag가 전체게시물을 tag해서 검색하는데에도 쓰이지만 user home에서 tag들 바탕으로 게시글 몇개 있는지 파악할 때에도 쓰이기에 저도 그쪽으로 제나름대로 서연님 모델 가지고 수정해보려고 합니다. 